### PR TITLE
cosette responses api fix

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -664,7 +664,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "conts = {'anthropic': cla.contents, 'openai': cos.contents}\n",
+    "conts = {'anthropic': cla.contents, 'openai': lambda r: getattr(r, 'output_text', r)}\n",
     "p = r'```(?:bash\\n|\\n)?([^`]+)```'\n",
     "def get_res(sage, q, provider, mode='default', verbosity=0):\n",
     "    if mode == 'command':\n",
@@ -1149,9 +1149,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "python3",
+   "display_name": "python",
    "language": "python",
-   "name": "python3"
+   "name": "python"
   }
  },
  "nbformat": 4,

--- a/shell_sage/core.py
+++ b/shell_sage/core.py
@@ -249,7 +249,7 @@ def trace(msgs):
             if tool_use: print(f'Tool use: {tool_use.name}\nTool input: {tool_use.input}')
 
 # %% ../nbs/00_core.ipynb 33
-conts = {'anthropic': cla.contents, 'openai': cos.contents}
+conts = {'anthropic': cla.contents, 'openai': lambda r: getattr(r, 'output_text', r)}
 p = r'```(?:bash\n|\n)?([^`]+)```'
 def get_res(sage, q, provider, mode='default', verbosity=0):
     if mode == 'command':


### PR DESCRIPTION
This PR fixes the removal of `contents()` in cosette which was changed in this [cosette commit](https://github.com/AnswerDotAI/cosette/commit/73353204ad6a080d7182563f2bbbd93eca99ec8a#diff-a3ce560c012c23204324a09d46cb324f4234ebe14a21520f8888bdbe8986a172L62-L67) in favor of [OpenAI Responses API](https://platform.openai.com/docs/guides/responses-vs-chat-completions).

```bash
(aai) ~/aai_git/aai_repos_extra/shell_sage (cosette-contents-fix ✔) ssage --provide openai --model gpt-4o-mini "hello what model empowers shellsage right now?"
Hello! ShellSage is powered by OpenAI's language models. However, I don't have access to my exact model name. My purpose is to assist you with shell commands and system administration. 
How can I help you today?                 
```