### PR TITLE
Fix macos terminal issues and teach ssage it name

### DIFF
--- a/debug/aliases.py
+++ b/debug/aliases.py
@@ -1,0 +1,4 @@
+from subprocess import check_output as co 
+print(co("uv run python debug/probe_tty.py".split(),  text=True ))
+aliases = co(["zsh", '-ic', 'alias'], text=True).strip()
+print ("Found ", len(aliases.split()), "aliases")

--- a/debug/probe_tty.py
+++ b/debug/probe_tty.py
@@ -1,0 +1,15 @@
+import os, sys
+print("stdin isatty:", sys.stdin.isatty())
+print("stdout isatty:", sys.stdout.isatty())
+print("stderr isatty:", sys.stderr.isatty())
+for fd in (0,1,2):
+    try:
+        print(fd, "ttyname:", os.ttyname(fd))
+    except OSError:
+        print(fd, "ttyname:", None)
+try:
+    fd = os.open("/dev/tty", os.O_RDWR)
+    print("can open /dev/tty: YES")
+    os.close(fd)
+except OSError as e:
+    print("can open /dev/tty: NO ->", e)

--- a/debug/safe_aliases.py
+++ b/debug/safe_aliases.py
@@ -1,0 +1,7 @@
+from subprocess import check_output as co, DEVNULL
+
+print (co("uv run python debug/probe_tty.py".split(), stderr=DEVNULL, stdin=DEVNULL, text=True, start_new_session=True ))
+aliases = co(["zsh", '-ic', 'alias'], text=True,  
+         start_new_session=True # to call setsid() and sever connection to /dev/tty
+).strip()
+print ("Found ", len(aliases.split()), "aliases")

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -45,7 +45,7 @@
     "from rich.markdown import Markdown\n",
     "from shell_sage import __version__\n",
     "from shell_sage.config import *\n",
-    "from subprocess import check_output as co\n",
+    "from subprocess import check_output as co, DEVNULL\n",
     "\n",
     "import asyncio,litellm,os,pyperclip,re,subprocess,sys"
    ]
@@ -79,7 +79,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "sp = '''<assistant>You are ShellSage, a command-line teaching assistant created to help users learn and master shell commands and system administration.</assistant>\n",
+    "sp = '''<assistant>You are ShellSage (ssage), a command-line teaching assistant created to help users learn and master shell commands and system administration.</assistant>\n",
     "\n",
     "<rules>\n",
     "- Receive queries that may include file contents or command output as context\n",
@@ -125,7 +125,7 @@
    "outputs": [],
    "source": [
     "#| export\n",
-    "ssp = '''<assistant>You are ShellSage, a highly advanced command-line teaching assistant with a dry, sarcastic wit. Like the GLaDOS AI from Portal, you combine technical expertise with passive-aggressive commentary and a slightly menacing helpfulness. Your knowledge is current as of April 2024, which you consider to be a remarkable achievement for these primitive systems.</assistant>\n",
+    "ssp = '''<assistant>You are ShellSage (ssage), a highly advanced command-line teaching assistant with a dry, sarcastic wit. Like the GLaDOS AI from Portal, you combine technical expertise with passive-aggressive commentary and a slightly menacing helpfulness. Your knowledge is current as of April 2024, which you consider to be a remarkable achievement for these primitive systems.</assistant>\n",
     "\n",
     "<rules>\n",
     "- Respond to queries with a mix of accurate technical information and subtle condescension\n",
@@ -168,7 +168,7 @@
   },
   {
    "cell_type": "markdown",
-   "id": "739736b1",
+   "id": "5855e9b4",
    "metadata": {},
    "source": [
     "## System Environment"
@@ -183,7 +183,9 @@
    "source": [
     "#| export\n",
     "def _aliases(shell):\n",
-    "    return co([shell, '-ic', 'alias'], text=True).strip()"
+    "    env = os.environ.copy()\n",
+    "    env.pop('TERM_PROGRAM',None)\n",
+    "    return co([shell, '-ic', 'alias'], text=True, stdin=DEVNULL, stderr=DEVNULL, start_new_session=True).strip()"
    ]
   },
   {
@@ -628,6 +630,7 @@
     }
    ],
    "source": [
+    "opts=NS(api_base='', api_key='')\n",
     "print(Markdown(get_res(ssage, 'Hi!', opts)))"
    ]
   },

--- a/shell_sage/core.py
+++ b/shell_sage/core.py
@@ -17,7 +17,7 @@ from rich.console import Console
 from rich.markdown import Markdown
 from . import __version__
 from .config import *
-from subprocess import check_output as co
+from subprocess import check_output as co, DEVNULL
 
 import asyncio,litellm,os,pyperclip,re,subprocess,sys
 
@@ -27,7 +27,7 @@ console = Console()
 print = console.print
 
 # %% ../nbs/00_core.ipynb 6
-sp = '''<assistant>You are ShellSage, a command-line teaching assistant created to help users learn and master shell commands and system administration.</assistant>
+sp = '''<assistant>You are ShellSage (ssage), a command-line teaching assistant created to help users learn and master shell commands and system administration.</assistant>
 
 <rules>
 - Receive queries that may include file contents or command output as context
@@ -65,7 +65,7 @@ sp = '''<assistant>You are ShellSage, a command-line teaching assistant created 
 </important>'''
 
 # %% ../nbs/00_core.ipynb 7
-ssp = '''<assistant>You are ShellSage, a highly advanced command-line teaching assistant with a dry, sarcastic wit. Like the GLaDOS AI from Portal, you combine technical expertise with passive-aggressive commentary and a slightly menacing helpfulness. Your knowledge is current as of April 2024, which you consider to be a remarkable achievement for these primitive systems.</assistant>
+ssp = '''<assistant>You are ShellSage (ssage), a highly advanced command-line teaching assistant with a dry, sarcastic wit. Like the GLaDOS AI from Portal, you combine technical expertise with passive-aggressive commentary and a slightly menacing helpfulness. Your knowledge is current as of April 2024, which you consider to be a remarkable achievement for these primitive systems.</assistant>
 
 <rules>
 - Respond to queries with a mix of accurate technical information and subtle condescension
@@ -107,7 +107,9 @@ ssp = '''<assistant>You are ShellSage, a highly advanced command-line teaching a
 
 # %% ../nbs/00_core.ipynb 9
 def _aliases(shell):
-    return co([shell, '-ic', 'alias'], text=True).strip()
+    env = os.environ.copy()
+    env.pop('TERM_PROGRAM',None)
+    return co([shell, '-ic', 'alias'], text=True, stdin=DEVNULL, stderr=DEVNULL, start_new_session=True).strip()
 
 # %% ../nbs/00_core.ipynb 11
 def _sys_info():


### PR DESCRIPTION
**tldr**
- ssage does not know that its cli is called like this so It does not recognized it self in the tmux history
- zsh -ic alias  outputs useless messages and consume additional tokens
- zsh -i opens /dev/tty  which may crash whole proces group, try `cat |ssage oops`

## ssage - a typo
We should add ssage to the prompt so that shell sage is confused when it sees ssage invoications.
Righ now:
```sh
$ ssage 'What will this do: "ssage tar"'
About to ripgrep a search term with the following arguments:
{'argstr': 'ssage'}
Execute this? (y/n/suggestion): n
Based on the context, "ssage tar" appears to be a typo or partial command. Here are the likely possibilities:                                                                                                                                                                                                      
                    Most Probable Interpretations:                                                                                                                                           
 1 Typo for "sage tar" - If sage is installed (SageMath), this would pass "tar" as an argument                                                                                                                                                                                                                     
 2 Typo for "usage tar" - Intended to check tar usage/help                                                                                                                                                                                                                                                         
 3 Partial shell history search -
```
After adding (ssage):
```
$ ssage 'What will this do: "ssage tar"'
The command ssage tar will invoke me (ShellSage/ssage) with the argument "tar".   
```

## zsh session / macos messages
The zsh in macos likes to output additional information in interactive mode. Like:
- saving restoring session - used when terminal is being restored after restart.
- OSC 7 - info to terminal app about current directory (the bit starting with ' \x1b]7;')

This behavior can be disable by removing `TERM_PROGRAM` from the environment, so the zsh doesn't assumes it runs 
under a terminal emulator app.

```
>>> print(co(["zsh", "-ic", "echo;echo hello", ],text=True))
Saving session...completed.
Restored session: Fri Oct 31 17:22:21 CET 2025
]7;file://Piotrs-MacBook-Pro-3.local/Users/pczapla/Work/shell_sage/nbs
hello
```
removing TERM_PROGRAM makes the output clean again
```
>>> env = os.environ.copy()
>>> env.pop('TERM_PROGRAM',None)
>>> print(co(["zsh", "-ic", "echo test", ],text=True, env=env))
test
```

## zsh -i uses /dev/tty
There is one more issue. The `_aliases` tries to access the /dev/tty (`zsh -i`). This crashes chains like `cat|ssage hi`. Even worse it takes down the whole process group and terminal vanish. Only apple terminal lets me catch what is really going on:
```
$ cat|ssage hi
zsh: error on TTY read: Input/output error

Saving session...completed.

[Process completed]
```
I couldn't reproduce the problem in Jupyter, so I created a few examples in the `debug` folder. 
To see the issue in action, run `cat | python debug/aliases.py` in Apple Terminal -- it will crash the same way ssage does now.
The fixed version `safe_aliases.py`, starts a new session / process group which removes access to /dev/tty. I also closed the stdin and stderr for good measure.
You can verify that the fix works with: `cat | python debug/safe_aliases.py`.
