### PR TITLE
Update Google Gemini model name in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,7 +386,7 @@ ssage --model gpt-5 --api_key <your_key_here> explain kubernetes pods
 #### Google Gemini
 
 ``` sh
-ssage --model gemini/gemini/gemini-2.5-flash --api_key <your_key_here> what is systemd?
+ssage --model gemini/gemini-2.5-pro --api_key <your_key_here> what is systemd?
 ```
 
 #### Other Providers


### PR DESCRIPTION
Using `gemini/gemini-pro` yields error:

```
litellm.exceptions.NotFoundError: litellm.NotFoundError: Vertex_ai_betaException - b'{\n  "error": {\n    "code": 404,\n    "message": "models/gemini-pro is not found for API version v1beta, or is not supported for generateContent. Call ListModels to see the list of available models and their supported methods.",\n    "status": "NOT_FOUND"\n  }\n}\n'
```

`gemini-pro-latest` doesn't seem to be mapped by litellm either
```
Exception: This model isn't mapped yet. model=gemini/gemini-pro-latest, custom_llm_provider=gemini. Add it here - https://github.com/BerriAI/litellm/blob/main/model_prices_and_context_window.json.
```

So best bet is `gemini-2.5-pro` or `gemini-2.5.flash`