### PR TITLE
add bash keyboard shortcut to extract codefences

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,6 +347,8 @@ ShellSage can be customized through a configuration file located at
     [DEFAULT]
     model = 'claude-sonnet-4-5-20250929'    # Your preferred model
     search = ''                             # Enable web search capability (can be either l,m,h https://lisette.answer.ai/#web-search)
+    think = ''                              # Enable thinking capability (can be either l,m,h)
+    trust = ''                              # Comma-delimeted list of tools to not ask for confirmation about
     mode = 'default'                        # or "sassy"
     api_base = ''                           # alternative api url base
     api_key = ''                            # alternative api key to use instead of default env var
@@ -483,6 +485,19 @@ script:
 ``` python
 !ssage_extract 0
 # inserts "du -ah . | sort -rh | head -20" into your tmux prompt
+```
+
+You can also bind a keyboard shortcut in Bash to insert code fences
+directly into your prompt. Type a block number (or leave empty for 0),
+then press `Ctrl+J` to insert that code block. To use this, add the
+following to your `~/.bashrc`:
+
+``` bash
+ssage-insert() {
+  local r=$(ssage_extract --do_print "${READLINE_LINE:-0}")
+  READLINE_LINE="$r" READLINE_POINT=${#r}
+}
+bind -x '"\C-j": ssage-insert'
 ```
 
 ### Enabling Sassy Mode

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -983,10 +983,13 @@
     "@call_parse\n",
     "def extract(\n",
     "    idx: int,  # Index of code block to extract\n",
-    "    copy: bool = False,  # Copy to clipboard vs send to tmux\n",
+    "    copy: bool = False,  # Copy to clipboard\n",
+    "    do_print: bool = False, # Print (useful for readline custom shortcuts)\n",
     "):\n",
+    "    \"Extracts the idx'th codefence from the last shell sage response and sends it to tmux by default\"\n",
     "    blk = extract_cf(idx)\n",
     "    if copy: pyperclip.copy(blk)\n",
+    "    elif do_print: print(blk)\n",
     "    else: subprocess.run(['tmux', 'send-keys', blk])"
    ]
   },

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -615,6 +615,22 @@
   },
   {
    "cell_type": "markdown",
+   "id": "9cc9b194",
+   "metadata": {},
+   "source": [
+    "You can also bind a keyboard shortcut in Bash to insert code fences directly into your prompt. Type a block number (or leave empty for 0), then press `Ctrl+J` to insert that code block. To use this, add the following to your `~/.bashrc`:\n",
+    "\n",
+    "```bash\n",
+    "ssage-insert() {\n",
+    "  local r=$(ssage_extract --do_print \"${READLINE_LINE:-0}\")\n",
+    "  READLINE_LINE=\"$r\" READLINE_POINT=${#r}\n",
+    "}\n",
+    "bind -x '\"\\C-j\": ssage-insert'\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "cca2c42c",
    "metadata": {},
    "source": [

--- a/shell_sage/core.py
+++ b/shell_sage/core.py
@@ -293,8 +293,11 @@ def extract_cf(idx): return re.findall(r'```(\w+)?\n(.*?)\n```', mk_db().logs()[
 @call_parse
 def extract(
     idx: int,  # Index of code block to extract
-    copy: bool = False,  # Copy to clipboard vs send to tmux
+    copy: bool = False,  # Copy to clipboard
+    do_print: bool = False, # Print (useful for readline custom shortcuts)
 ):
+    "Extracts the idx'th codefence from the last shell sage response and sends it to tmux by default"
     blk = extract_cf(idx)
     if copy: pyperclip.copy(blk)
+    elif do_print: print(blk)
     else: subprocess.run(['tmux', 'send-keys', blk])


### PR DESCRIPTION
W this PR you can extract codefences also from bash. This is useful because:
1. it works outside of tmux
2. it's faster than tmux (fewer keystrokes, and more responsive than `tmux send-keys`)

https://github.com/user-attachments/assets/3dcbd054-bc61-4259-945f-a77dc1b6d133

