### PR TITLE
add symlink to ./nbs/tmux.conf

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -1,0 +1,1 @@
+./nbs/tmux.conf


### PR DESCRIPTION
With PR #73, in README.md the link to "tmux configuration" will give 404 error when navigated from github.com, as the link is meant to work for Quarto-generated page at https://ssage.answer.ai/ (Quarto will copy the artefacts e.g. `tmux.conf` into the correct website root folder).

This PR adds a symlink from `tmux.conf` to `./nbs/tmux.conf`, so that when navigated from github.com the link will show where it symlinks to, and in CLI it points to the correct file (without having duplicated files).