### PR TITLE
Allow backend to come from config

### DIFF
--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -1145,7 +1145,7 @@
     "    code_theme: str = None,  # The code theme to use when rendering ShellSage's responses\n",
     "    code_lexer: str = None,  # The lexer to use for inline code markdown blocks\n",
     "    raw: bool = False,  # Skip markdown rendering and print plain text\n",
-    "    backend: str = 'lisette',  # Backend to use: 'lisette' or 'fastllm'\n",
+    "    backend: str = None,  # Backend to use. Defaults to shell_sage config.\n",
     "    vendor_name: str = None,  # Vendor name for fastllm backend (e.g. 'fireworks_ai')\n",
     "):\n",
     "    safecmd = None\n",

--- a/shell_sage/core.py
+++ b/shell_sage/core.py
@@ -281,7 +281,7 @@ async def main(
     code_theme: str = None,  # The code theme to use when rendering ShellSage's responses
     code_lexer: str = None,  # The lexer to use for inline code markdown blocks
     raw: bool = False,  # Skip markdown rendering and print plain text
-    backend: str = 'lisette',  # Backend to use: 'lisette' or 'fastllm'
+    backend: str = None,  # Backend to use. Defaults to shell_sage config.
     vendor_name: str = None,  # Vendor name for fastllm backend (e.g. 'fireworks_ai')
 ):
     safecmd = None


### PR DESCRIPTION
The CLI default for backend was always "lisette", so get_opts never read the backend value from shell_sage.conf. Use None as the CLI default so configured values like backend = fastllm can take effect.