### PR TITLE
allow custom instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,6 +370,7 @@ ShellSage can be customized through a configuration file located at
     code_lexer = "python"                   # Default lexer for inline code blocks
     log = False                             # Enable SQLite logging (required for code extraction)
     safecmd = False                         # Enable the safecmd-backed bash tool
+    custom_instructions = ''                # Extra instructions appended to the system prompt
 
 ### Using Different Model Providers
 

--- a/nbs/00_core.ipynb
+++ b/nbs/00_core.ipynb
@@ -66,7 +66,8 @@
     "#| hide\n",
     "from contextlib import contextmanager\n",
     "from IPython.display import clear_output\n",
-    "from cachy import enable_cachy"
+    "from cachy import enable_cachy\n",
+    "from fastcore.test import *"
    ]
   },
   {
@@ -476,16 +477,16 @@
     {
      "data": {
       "text/markdown": [
-       "<div class=\"prose\">\n",
+       "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
        "```python\n",
-       "{'api_base': '', 'api_key': '', 'log': True, 'model': 'claude-sonnet-4-6'}\n",
+       "{'api_base': None, 'api_key': '', 'log': True, 'model': 'claude-opus-4-6'}\n",
        "```\n",
        "\n",
        "</div>"
       ],
       "text/plain": [
-       "{'model': 'claude-sonnet-4-6', 'log': True, 'api_base': '', 'api_key': ''}"
+       "{'model': 'claude-opus-4-6', 'log': True, 'api_base': None, 'api_key': ''}"
       ]
      },
      "execution_count": null,
@@ -589,29 +590,29 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Directory contents of <span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">nbs</span>:\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">00_core.ipynb</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">67.</span>2k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">_quarto.yml</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>3k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">sidebar.yml</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>1k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">styles.css</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>6k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">CNAME</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>0k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">01_config.ipynb</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4.</span>1k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">tmux.conf</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1.</span>4k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">nbdev.yml</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>2k<span style=\"font-weight: bold\">)</span>\n",
-       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/keremturgutlu/aai-ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">index.ipynb</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">64.</span>4k<span style=\"font-weight: bold\">)</span>\n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Directory contents of <span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">nbs</span>:\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">00_core.ipynb</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">28.</span>9k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">_quarto.yml</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>3k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">sidebar.yml</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>1k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">styles.css</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>6k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">CNAME</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>0k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">01_config.ipynb</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">4.</span>1k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">tmux.conf</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">1.</span>4k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">nbdev.yml</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">0.</span>2k<span style=\"font-weight: bold\">)</span>\n",
+       "<span style=\"color: #800080; text-decoration-color: #800080\">/Users/rensdimmendaal/aai/ws/shell_sage/nbs/</span><span style=\"color: #ff00ff; text-decoration-color: #ff00ff\">index.ipynb</span> <span style=\"font-weight: bold\">(</span><span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65.</span>2k<span style=\"font-weight: bold\">)</span>\n",
        "</pre>\n"
       ],
       "text/plain": [
-       "Directory contents of \u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/\u001b[0m\u001b[95mnbs\u001b[0m:\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95m00_core.ipynb\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m67.\u001b[0m2k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95m_quarto.yml\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m3k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95msidebar.yml\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m1k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95mstyles.css\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m6k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95mCNAME\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m0k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95m01_config.ipynb\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m4.\u001b[0m1k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95mtmux.conf\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m1.\u001b[0m4k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95mnbdev.yml\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m2k\u001b[1m)\u001b[0m\n",
-       "\u001b[35m/Users/keremturgutlu/aai-ws/shell_sage/nbs/\u001b[0m\u001b[95mindex.ipynb\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m64.\u001b[0m4k\u001b[1m)\u001b[0m\n"
+       "Directory contents of \u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/\u001b[0m\u001b[95mnbs\u001b[0m:\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95m00_core.ipynb\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m28.\u001b[0m9k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95m_quarto.yml\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m3k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95msidebar.yml\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m1k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95mstyles.css\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m6k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95mCNAME\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m0k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95m01_config.ipynb\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m4.\u001b[0m1k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95mtmux.conf\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m1.\u001b[0m4k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95mnbdev.yml\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m0.\u001b[0m2k\u001b[1m)\u001b[0m\n",
+       "\u001b[35m/Users/rensdimmendaal/aai/ws/shell_sage/nbs/\u001b[0m\u001b[95mindex.ipynb\u001b[0m \u001b[1m(\u001b[0m\u001b[1;36m65.\u001b[0m2k\u001b[1m)\u001b[0m\n"
       ]
      },
      "metadata": {},
@@ -632,10 +633,12 @@
     "#| export\n",
     "sps = {'default': sp, 'sassy': ssp}\n",
     "@delegates(AsyncChat)\n",
-    "def get_sage(model, mode='default', search=False, use_safecmd=False, vendor_name=None, **kwargs):\n",
+    "def get_sage(model, mode='default', search=False, use_safecmd=False, vendor_name=None, custom_instructions=None, **kwargs):\n",
     "    t = tools + [bash] if use_safecmd else tools\n",
     "    if use_safecmd: _always_allow.add('bash')\n",
-    "    return AsyncChat(model=model, sp=sps[mode], tools=t, search=search, vendor_name=vendor_name, **kwargs)"
+    "    sysp = sps[mode]\n",
+    "    if custom_instructions: sysp += f'\\n\\n<custom_instructions>\\n{custom_instructions}\\n</custom_instructions>'\n",
+    "    return AsyncChat(model=model, sp=sysp, tools=t, search=search, vendor_name=vendor_name, **kwargs)"
    ]
   },
   {
@@ -659,24 +662,24 @@
     {
      "data": {
       "text/markdown": [
-       "<div class=\"prose\">\n",
+       "<div class=\"prose\" markdown=\"1\">\n",
        "\n",
-       "Hey! Doing great, thanks for asking! I'm ShellSage, your command-line teaching assistant. 🐚\n",
+       "I'm doing great, thanks for asking! Ready to help you navigate the command line. 🖥️\n",
        "\n",
-       "Ready to help you navigate the shell, learn commands, or tackle any system administration challenges. What can I help you with today?\n",
+       "What shell commands or sysadmin topics can I help you with today?\n",
        "\n",
-       "<details>\n",
+       "<details markdown='1'>\n",
        "\n",
        "- model: `claude-sonnet-4-6`\n",
        "- finish_reason: `stop`\n",
-       "- usage: `Usage(prompt_tokens=5978, completion_tokens=58, total_tokens=6036, cached_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, raw={'input_tokens': 5978, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'cache_creation': {'ephemeral_5m_input_tokens': 0, 'ephemeral_1h_input_tokens': 0}, 'output_tokens': 58, 'service_tier': 'standard', 'inference_geo': 'global'})`\n",
+       "- usage: `Usage(prompt_tokens=3811, completion_tokens=43, total_tokens=3854, cached_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, raw={'input_tokens': 3811, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'cache_creation': {'ephemeral_5m_input_tokens': 0, 'ephemeral_1h_input_tokens': 0}, 'output_tokens': 43, 'output_tokens_details': {'thinking_tokens': 0}, 'service_tier': 'standard', 'inference_geo': 'global'})`\n",
        "\n",
        "</details>\n",
        "\n",
        "</div>"
       ],
       "text/plain": [
-       "Completion(model='claude-sonnet-4-6', message=Msg(role='assistant', content=[Part(type=<PartType.text: 'text'>, text=\"Hey! Doing great, thanks for asking! I'm ShellSage, your command-line teaching assistant. 🐚\\n\\nReady to help you navigate the shell, learn commands, or tackle any system administration challenges. What can I help you with today?\", data={'type': 'text', 'text': \"Hey! Doing great, thanks for asking! I'm ShellSage, your command-line teaching assistant. 🐚\\n\\nReady to help you navigate the shell, learn commands, or tackle any system administration challenges. What can I help you with today?\"})]), finish_reason=<finish_reason.stop: 'stop'>, usage=Usage(prompt_tokens=5978, completion_tokens=58, total_tokens=6036, cached_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, raw={'input_tokens': 5978, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'cache_creation': {'ephemeral_5m_input_tokens': 0, 'ephemeral_1h_input_tokens': 0}, 'output_tokens': 58, 'service_tier': 'standard', 'inference_geo': 'global'}), tool_calls=[], api_name='anthropic', vendor_name='anthropic', raw={'model': 'claude-sonnet-4-6', 'id': 'msg_01Ez3KQ3ybycNxVo3kG6eFAG', 'type': 'message', 'role': 'assistant', 'content': [{'type': 'text', 'text': \"Hey! Doing great, thanks for asking! I'm ShellSage, your command-line teaching assistant. 🐚\\n\\nReady to help you navigate the shell, learn commands, or tackle any system administration challenges. What can I help you with today?\"}], 'stop_reason': 'end_turn', 'stop_sequence': None, 'stop_details': None, 'usage': {'input_tokens': 5978, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'cache_creation': {'ephemeral_5m_input_tokens': 0, 'ephemeral_1h_input_tokens': 0}, 'output_tokens': 58, 'service_tier': 'standard', 'inference_geo': 'global'}})"
+       "Completion(model='claude-sonnet-4-6', message=Msg(role='assistant', content=[Part(type=<PartType.text: 'text'>, text=\"I'm doing great, thanks for asking! Ready to help you navigate the command line. 🖥️\\n\\nWhat shell commands or sysadmin topics can I help you with today?\", data={'type': 'text', 'text': \"I'm doing great, thanks for asking! Ready to help you navigate the command line. 🖥️\\n\\nWhat shell commands or sysadmin topics can I help you with today?\"})]), finish_reason=<finish_reason.stop: 'stop'>, usage=Usage(prompt_tokens=3811, completion_tokens=43, total_tokens=3854, cached_tokens=0, cache_creation_tokens=0, reasoning_tokens=0, raw={'input_tokens': 3811, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'cache_creation': {'ephemeral_5m_input_tokens': 0, 'ephemeral_1h_input_tokens': 0}, 'output_tokens': 43, 'output_tokens_details': {'thinking_tokens': 0}, 'service_tier': 'standard', 'inference_geo': 'global'}), tool_calls=[], api_name='anthropic', vendor_name='anthropic', raw={'model': 'claude-sonnet-4-6', 'id': 'msg_013nimY4vS2LXn6VeeB4meMi', 'type': 'message', 'role': 'assistant', 'content': [{'type': 'text', 'text': \"I'm doing great, thanks for asking! Ready to help you navigate the command line. 🖥️\\n\\nWhat shell commands or sysadmin topics can I help you with today?\"}], 'stop_reason': 'end_turn', 'stop_sequence': None, 'stop_details': None, 'usage': {'input_tokens': 3811, 'cache_creation_input_tokens': 0, 'cache_read_input_tokens': 0, 'cache_creation': {'ephemeral_5m_input_tokens': 0, 'ephemeral_1h_input_tokens': 0}, 'output_tokens': 43, 'output_tokens_details': {'thinking_tokens': 0}, 'service_tier': 'standard', 'inference_geo': 'global'}})"
       ]
      },
      "execution_count": null,
@@ -718,7 +721,7 @@
     {
      "data": {
       "text/plain": [
-       "['No', 'No.']"
+       "['No.']"
       ]
      },
      "execution_count": null,
@@ -740,11 +743,11 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Hey! What shell command or sysadmin topic can I help you with today? 😊                                            \n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Hi! What shell or sysadmin topic can I help you with today? 😊                                                     \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "Hey! What shell command or sysadmin topic can I help you with today? 😊                                            \n"
+       "Hi! What shell or sysadmin topic can I help you with today? 😊                                                     \n"
       ]
      },
      "metadata": {},
@@ -773,16 +776,12 @@
      "data": {
       "text/html": [
        "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">The current directory contains the following files: <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">_quarto.yml</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">00_core.ipynb</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">01_config.ipynb</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">CNAME</span>,            \n",
-       "<span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">index.ipynb</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">nbdev.yml</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">sidebar.yml</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">styles.css</span>, and <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">tmux.conf</span>. It looks like a project using <a href=\"https://nbdev.fast.ai/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">nbdev</span></a> (a             \n",
-       "Jupyter-notebook-driven development framework) with Quarto for documentation, along with a tmux configuration file \n",
-       "and some CSS styling.                                                                                              \n",
+       "<span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">index.ipynb</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">nbdev.yml</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">sidebar.yml</span>, <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">styles.css</span>, and <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">tmux.conf</span>.                                                    \n",
        "</pre>\n"
       ],
       "text/plain": [
        "The current directory contains the following files: \u001b[1;36;40m_quarto.yml\u001b[0m, \u001b[1;36;40m00_core.ipynb\u001b[0m, \u001b[1;36;40m01_config.ipynb\u001b[0m, \u001b[1;36;40mCNAME\u001b[0m,            \n",
-       "\u001b[1;36;40mindex.ipynb\u001b[0m, \u001b[1;36;40mnbdev.yml\u001b[0m, \u001b[1;36;40msidebar.yml\u001b[0m, \u001b[1;36;40mstyles.css\u001b[0m, and \u001b[1;36;40mtmux.conf\u001b[0m. It looks like a project using \u001b]8;id=7345984;https://nbdev.fast.ai/\u001b\\\u001b[4;34mnbdev\u001b[0m\u001b]8;;\u001b\\ (a             \n",
-       "Jupyter-notebook-driven development framework) with Quarto for documentation, along with a tmux configuration file \n",
-       "and some CSS styling.                                                                                              \n"
+       "\u001b[1;36;40mindex.ipynb\u001b[0m, \u001b[1;36;40mnbdev.yml\u001b[0m, \u001b[1;36;40msidebar.yml\u001b[0m, \u001b[1;36;40mstyles.css\u001b[0m, and \u001b[1;36;40mtmux.conf\u001b[0m.                                                    \n"
       ]
      },
      "metadata": {},
@@ -802,27 +801,29 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Here are some fascinating facts about Linux! <a href=\"https://medium.com/@teendifferent/fun-facts-about-linux-from-its-origin-story-to-unique-features-9cab290f8c9\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>Linux was created in 1991 by Linus Torvalds, a Finnish computer      \n",
-       "science student, who was frustrated with the limitations of existing Unix systems and wanted a freely available,   \n",
-       "community-improvable alternative. <a href=\"https://www.omgubuntu.co.uk/2018/08/interesting-facts-about-linux\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>It very nearly wasn't called \"Linux\" — Linus wanted to name it \"FreaX,\" but the \n",
-       "owner of the server hosting his early code preferred \"Linux\" (a blend of \"Linus\" and \"Unix\") and the name stuck.   \n",
-       "<a href=\"https://www.bitdefender.com/en-us/blog/hotforsecurity/ten-facts-you-might-now-know-about-linux\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>Out of the top 500 fastest supercomputers in the world, Linux powers 485 of them. <a href=\"https://itsfoss.com/facts-linux-kernel/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>The International Space Station\n",
-       "has been running Linux since 2013. <a href=\"https://linuxiac.com/10-interesting-and-fun-facts-about-linux/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>There's even a hidden Easter egg in the Linux <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">reboot()</span> system call — it has    \n",
-       "safeguards to prevent accidental reboots, including a <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">magic1</span> argument that only accepts the value <span style=\"color: #008080; text-decoration-color: #008080; background-color: #000000; font-weight: bold\">0xfee1dead</span>. <a href=\"https://linuxiac.com/10-interesting-and-fun-facts-about-linux/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>And \n",
-       "perhaps the quirkiest fact: \"Linux\" is also a genuine washing powder brand in Switzerland, sharing its name with   \n",
-       "Torvalds' kernel.                                                                                                  \n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Here are some fascinating facts about Linux: <a href=\"https://medium.com/@teendifferent/fun-facts-about-linux-from-its-origin-story-to-unique-features-9cab290f8c9\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>Linus Torvalds, a Finnish computer science student, created the first\n",
+       "version of Linux in 1991 as a hobby project while studying at the University of Helsinki. <a href=\"https://www.omgubuntu.co.uk/2018/08/interesting-facts-about-linux\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>He originally wanted to \n",
+       "call it \"FreaX\" (a combination of \"free\", \"freak\", and \"Unix\"), but was persuaded otherwise by the owner of the    \n",
+       "server hosting his early code, who preferred the name \"Linux.\" <a href=\"https://www.redhat.com/en/blog/28-facts-about-linux-its-28th-birthday\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>The first Linux release weighed in at less than 1MB\n",
+       "uncompressed — quite a contrast to today, and <a href=\"https://www.geeksforgeeks.org/interesting-facts-about-linux/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>all 500 of the fastest supercomputers in the world now run Linux.   \n",
+       "<a href=\"https://itsfoss.com/facts-linux-kernel/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>The International Space Station has been running Linux since 2013. <a href=\"https://www.geeksforgeeks.org/interesting-facts-about-linux/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>Linux is written over 95% in C language, and  \n",
+       "<a href=\"https://itsfoss.com/facts-linux-kernel/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>today over 80% of Linux contributions come from developers paid by big enterprises, with Intel topping the list of\n",
+       "contributors for most kernel releases. On a fun note, <a href=\"https://linuxiac.com/10-interesting-and-fun-facts-about-linux/\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>Linux is also a genuine washing powder brand in Switzerland,\n",
+       "and <a href=\"https://www.redhat.com/en/blog/28-facts-about-linux-its-28th-birthday\" target=\"_blank\"><span style=\"color: #000080; text-decoration-color: #000080; text-decoration: underline\">*</span></a>one of the unexpected workloads for Linux has been milking cows — the DeLaval \"Voluntary Milking System\" lets \n",
+       "cows decide when they'll be milked, all managed by a single-board computer running Linux!                          \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "Here are some fascinating facts about Linux! \u001b]8;id=7346372;https://medium.com/@teendifferent/fun-facts-about-linux-from-its-origin-story-to-unique-features-9cab290f8c9\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\Linux was created in 1991 by Linus Torvalds, a Finnish computer      \n",
-       "science student, who was frustrated with the limitations of existing Unix systems and wanted a freely available,   \n",
-       "community-improvable alternative. \u001b]8;id=7346373;https://www.omgubuntu.co.uk/2018/08/interesting-facts-about-linux\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\It very nearly wasn't called \"Linux\" — Linus wanted to name it \"FreaX,\" but the \n",
-       "owner of the server hosting his early code preferred \"Linux\" (a blend of \"Linus\" and \"Unix\") and the name stuck.   \n",
-       "\u001b]8;id=7346374;https://www.bitdefender.com/en-us/blog/hotforsecurity/ten-facts-you-might-now-know-about-linux\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\Out of the top 500 fastest supercomputers in the world, Linux powers 485 of them. \u001b]8;id=7346375;https://itsfoss.com/facts-linux-kernel/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\The International Space Station\n",
-       "has been running Linux since 2013. \u001b]8;id=7346376;https://linuxiac.com/10-interesting-and-fun-facts-about-linux/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\There's even a hidden Easter egg in the Linux \u001b[1;36;40mreboot()\u001b[0m system call — it has    \n",
-       "safeguards to prevent accidental reboots, including a \u001b[1;36;40mmagic1\u001b[0m argument that only accepts the value \u001b[1;36;40m0xfee1dead\u001b[0m. \u001b]8;id=7346376;https://linuxiac.com/10-interesting-and-fun-facts-about-linux/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\And \n",
-       "perhaps the quirkiest fact: \"Linux\" is also a genuine washing powder brand in Switzerland, sharing its name with   \n",
-       "Torvalds' kernel.                                                                                                  \n"
+       "Here are some fascinating facts about Linux: \u001b]8;id=10689455;https://medium.com/@teendifferent/fun-facts-about-linux-from-its-origin-story-to-unique-features-9cab290f8c9\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\Linus Torvalds, a Finnish computer science student, created the first\n",
+       "version of Linux in 1991 as a hobby project while studying at the University of Helsinki. \u001b]8;id=10689456;https://www.omgubuntu.co.uk/2018/08/interesting-facts-about-linux\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\He originally wanted to \n",
+       "call it \"FreaX\" (a combination of \"free\", \"freak\", and \"Unix\"), but was persuaded otherwise by the owner of the    \n",
+       "server hosting his early code, who preferred the name \"Linux.\" \u001b]8;id=10689457;https://www.redhat.com/en/blog/28-facts-about-linux-its-28th-birthday\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\The first Linux release weighed in at less than 1MB\n",
+       "uncompressed — quite a contrast to today, and \u001b]8;id=10689458;https://www.geeksforgeeks.org/interesting-facts-about-linux/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\all 500 of the fastest supercomputers in the world now run Linux.   \n",
+       "\u001b]8;id=10689459;https://itsfoss.com/facts-linux-kernel/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\The International Space Station has been running Linux since 2013. \u001b]8;id=10689458;https://www.geeksforgeeks.org/interesting-facts-about-linux/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\Linux is written over 95% in C language, and  \n",
+       "\u001b]8;id=10689459;https://itsfoss.com/facts-linux-kernel/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\today over 80% of Linux contributions come from developers paid by big enterprises, with Intel topping the list of\n",
+       "contributors for most kernel releases. On a fun note, \u001b]8;id=10689460;https://linuxiac.com/10-interesting-and-fun-facts-about-linux/\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\Linux is also a genuine washing powder brand in Switzerland,\n",
+       "and \u001b]8;id=10689457;https://www.redhat.com/en/blog/28-facts-about-linux-its-28th-birthday\u001b\\\u001b[4;34m*\u001b[0m\u001b]8;;\u001b\\one of the unexpected workloads for Linux has been milking cows — the DeLaval \"Voluntary Milking System\" lets \n",
+       "cows decide when they'll be milked, all managed by a single-board computer running Linux!                          \n"
       ]
      },
      "metadata": {},
@@ -906,12 +907,13 @@
     "    code_theme: str = None,  # The code theme to use when rendering ShellSage's responses\n",
     "    code_lexer: str = None,  # The lexer to use for inline code markdown blocks\n",
     "    raw: bool = False,  # Skip markdown rendering and print plain text\n",
+    "    custom_instructions: str = None,  # Extra instructions appended to the system prompt\n",
     "):\n",
     "    safecmd = None\n",
     "    opts = get_opts(history_lines=history_lines, model=model, search=search,\n",
     "                    base_url=base_url, api_key=api_key, code_theme=code_theme,\n",
     "                    code_lexer=code_lexer, think=think, trust=trust, safecmd=safecmd,\n",
-    "                    vendor_name=vendor_name, log=None)\n",
+    "                    vendor_name=vendor_name, log=None, custom_instructions=custom_instructions)\n",
     "    if opts.trust: _always_allow.update(t.strip() for t in opts.trust.split(','))\n",
     "    res=\"\"\n",
     "    try:\n",
@@ -945,7 +947,7 @@
     "            \n",
     "            query = f'{ctxt}\\n<query>\\n{query}\\n</query>'\n",
     "\n",
-    "            sage = get_sage(opts.model, mode, search=opts.search, use_safecmd=opts.safecmd, vendor_name=opts.vendor_name)\n",
+    "            sage = get_sage(opts.model, mode, search=opts.search, use_safecmd=opts.safecmd, vendor_name=opts.vendor_name, custom_instructions=opts.custom_instructions)\n",
     "            async for res in get_res(sage, query, opts): live.update(_md(res), refresh=True)\n",
     "            \n",
     "        # Handle logging if the log flag is set\n",
@@ -965,29 +967,35 @@
     {
      "data": {
       "text/html": [
-       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">No, I don't have a <span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">bash</span> (or shell execution) tool. My available tools are:                                         \n",
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">No, I don't have a <span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">bash</span> tool. My available tools are:                                                              \n",
        "\n",
-       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">view</span> — view file/directory contents                                                                             \n",
-       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">rg</span> — search files using <span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">ripgrep</span>                                                                                 \n",
-       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">create</span> — create new files                                                                                       \n",
-       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">str_replace</span> — edit files by replacing text                                                                      \n",
-       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">insert</span> — insert text at a line number                                                                           \n",
+       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">rg</span> — run ripgrep searches                                                                                       \n",
+       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">view</span> — view files/directories                                                                                   \n",
+       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">create</span> / <span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">str_replace</span> / <span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">insert</span> — edit files                                                                      \n",
+       "<span style=\"font-weight: bold\"> • </span><span style=\"color: #f8f8f2; text-decoration-color: #f8f8f2; background-color: #272822\">web_search</span> — search the web                                                                                     \n",
        "\n",
-       "I can read and modify files, and search codebases, but I cannot execute arbitrary shell commands. If you need to   \n",
-       "run something, you'll need to do that in your terminal directly.                                                   \n",
+       "So I can read and edit files, and search through code, but I can't execute arbitrary shell commands. That's by     \n",
+       "design — the idea is for <span style=\"font-weight: bold\">you</span> to run the commands in your terminal, which keeps you in the driver's seat for        \n",
+       "learning.                                                                                                          \n",
+       "\n",
+       "If you need me to look something up in your project files, I can do that. But for running commands, I'll give you  \n",
+       "the snippet to paste and run yourself.                                                                             \n",
        "</pre>\n"
       ],
       "text/plain": [
-       "No, I don't have a \u001b[38;2;248;248;242;48;2;39;40;34mbash\u001b[0m (or shell execution) tool. My available tools are:                                         \n",
+       "No, I don't have a \u001b[38;2;248;248;242;48;2;39;40;34mbash\u001b[0m tool. My available tools are:                                                              \n",
        "\n",
-       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mview\u001b[0m — view file/directory contents                                                                             \n",
-       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mrg\u001b[0m — search files using \u001b[38;2;248;248;242;48;2;39;40;34mripgrep\u001b[0m                                                                                 \n",
-       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mcreate\u001b[0m — create new files                                                                                       \n",
-       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mstr_replace\u001b[0m — edit files by replacing text                                                                      \n",
-       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34minsert\u001b[0m — insert text at a line number                                                                           \n",
+       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mrg\u001b[0m — run ripgrep searches                                                                                       \n",
+       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mview\u001b[0m — view files/directories                                                                                   \n",
+       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mcreate\u001b[0m / \u001b[38;2;248;248;242;48;2;39;40;34mstr_replace\u001b[0m / \u001b[38;2;248;248;242;48;2;39;40;34minsert\u001b[0m — edit files                                                                      \n",
+       "\u001b[1m • \u001b[0m\u001b[38;2;248;248;242;48;2;39;40;34mweb_search\u001b[0m — search the web                                                                                     \n",
        "\n",
-       "I can read and modify files, and search codebases, but I cannot execute arbitrary shell commands. If you need to   \n",
-       "run something, you'll need to do that in your terminal directly.                                                   \n"
+       "So I can read and edit files, and search through code, but I can't execute arbitrary shell commands. That's by     \n",
+       "design — the idea is for \u001b[1myou\u001b[0m to run the commands in your terminal, which keeps you in the driver's seat for        \n",
+       "learning.                                                                                                          \n",
+       "\n",
+       "If you need me to look something up in your project files, I can do that. But for running commands, I'll give you  \n",
+       "the snippet to paste and run yourself.                                                                             \n"
       ]
      },
      "metadata": {},
@@ -996,6 +1004,39 @@
    ],
    "source": [
     "await main(['Do you have a `bash` tool?.'], history_lines=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0e0ec1da",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<pre style=\"white-space:pre;overflow-x:auto;line-height:normal;font-family:Menlo,'DejaVu Sans Mono',consolas,'Courier New',monospace\">Arrr, ahoy there, matey! 🏴‍☠️                                                                                        \n",
+       "\n",
+       "Welcome aboard! Looks like ye've just been editin' yer Shell Sage config file. What can this ol' sea dog help ye   \n",
+       "with today? Whether it be shell commands, system administration, or navigatin' the treacherous waters of the       \n",
+       "terminal — I be at yer service!                                                                                    \n",
+       "</pre>\n"
+      ],
+      "text/plain": [
+       "Arrr, ahoy there, matey! 🏴‍☠️                                                                                        \n",
+       "\n",
+       "Welcome aboard! Looks like ye've just been editin' yer Shell Sage config file. What can this ol' sea dog help ye   \n",
+       "with today? Whether it be shell commands, system administration, or navigatin' the treacherous waters of the       \n",
+       "terminal — I be at yer service!                                                                                    \n"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "await main(['Hello!'], history_lines=0, custom_instructions='Talk like a pirate. Start every reply with \"Arrr,\"')\n",
+    "test_eq(_res.startswith('Arrr,'), True)\n"
    ]
   },
   {
@@ -1031,7 +1072,7 @@
     {
      "data": {
       "text/plain": [
-       "Log(id=90, timestamp='2026-05-12T14:56:02.528405', query='', response=\"\\nHello, user! Here are some code blocks:\\n\\n```python\\nfor i in range(10): print(i)\\n```\\n\\n```\\nThis doesn't even have a language definition!\\n```\\n\\n```bash\\nls **/*\\n```\\n\", model='', mode='')"
+       "Log(id=799, timestamp='2026-05-28T15:23:20.783718', query='', response=\"\\nHello, user! Here are some code blocks:\\n\\n```python\\nfor i in range(10): print(i)\\n```\\n\\n```\\nThis doesn't even have a language definition!\\n```\\n\\n```bash\\nls **/*\\n```\\n\", model='', mode='')"
       ]
      },
      "execution_count": null,

--- a/nbs/01_config.ipynb
+++ b/nbs/01_config.ipynb
@@ -106,7 +106,8 @@
     "    code_theme: str = \"monokai\"\n",
     "    code_lexer: str = \"python\"\n",
     "    log: bool = False\n",
-    "    safecmd: bool = False"
+    "    safecmd: bool = False\n",
+    "    custom_instructions: str = ''"
    ]
   },
   {

--- a/nbs/index.ipynb
+++ b/nbs/index.ipynb
@@ -568,6 +568,7 @@
     "code_lexer = \"python\"                   # Default lexer for inline code blocks\n",
     "log = False                             # Enable SQLite logging (required for code extraction)\n",
     "safecmd = False                         # Enable the safecmd-backed bash tool\n",
+    "custom_instructions = ''                # Extra instructions appended to the system prompt\n",
     "```"
    ]
   },

--- a/shell_sage/config.py
+++ b/shell_sage/config.py
@@ -34,6 +34,7 @@ class ShellSageConfig:
     code_lexer: str = "python"
     log: bool = False
     safecmd: bool = False
+    custom_instructions: str = ''
 
 # %% ../nbs/01_config.ipynb #38e35cce
 def get_cfg():

--- a/shell_sage/core.py
+++ b/shell_sage/core.py
@@ -226,10 +226,12 @@ tools = [with_permission('ripgrep a search term')(rg),
 # %% ../nbs/00_core.ipynb #619df024
 sps = {'default': sp, 'sassy': ssp}
 @delegates(AsyncChat)
-def get_sage(model, mode='default', search=False, use_safecmd=False, vendor_name=None, **kwargs):
+def get_sage(model, mode='default', search=False, use_safecmd=False, vendor_name=None, custom_instructions=None, **kwargs):
     t = tools + [bash] if use_safecmd else tools
     if use_safecmd: _always_allow.add('bash')
-    return AsyncChat(model=model, sp=sps[mode], tools=t, search=search, vendor_name=vendor_name, **kwargs)
+    sysp = sps[mode]
+    if custom_instructions: sysp += f'\n\n<custom_instructions>\n{custom_instructions}\n</custom_instructions>'
+    return AsyncChat(model=model, sp=sysp, tools=t, search=search, vendor_name=vendor_name, **kwargs)
 
 # %% ../nbs/00_core.ipynb #2788faf4
 @delegates(AsyncChat._call)
@@ -271,12 +273,13 @@ async def main(
     code_theme: str = None,  # The code theme to use when rendering ShellSage's responses
     code_lexer: str = None,  # The lexer to use for inline code markdown blocks
     raw: bool = False,  # Skip markdown rendering and print plain text
+    custom_instructions: str = None,  # Extra instructions appended to the system prompt
 ):
     safecmd = None
     opts = get_opts(history_lines=history_lines, model=model, search=search,
                     base_url=base_url, api_key=api_key, code_theme=code_theme,
                     code_lexer=code_lexer, think=think, trust=trust, safecmd=safecmd,
-                    vendor_name=vendor_name, log=None)
+                    vendor_name=vendor_name, log=None, custom_instructions=custom_instructions)
     if opts.trust: _always_allow.update(t.strip() for t in opts.trust.split(','))
     res=""
     try:
@@ -310,7 +313,7 @@ async def main(
             
             query = f'{ctxt}\n<query>\n{query}\n</query>'
 
-            sage = get_sage(opts.model, mode, search=opts.search, use_safecmd=opts.safecmd, vendor_name=opts.vendor_name)
+            sage = get_sage(opts.model, mode, search=opts.search, use_safecmd=opts.safecmd, vendor_name=opts.vendor_name, custom_instructions=opts.custom_instructions)
             async for res in get_res(sage, query, opts): live.update(_md(res), refresh=True)
             
         # Handle logging if the log flag is set


### PR DESCRIPTION
Adds a custom_instructions setting. I noticed `nbdev-test` fails in main and I didnt fix that in this PR. I can confirm all nbs run end2end and the feature works in regular use via the `--custom_instructions` or config file.