### PR TITLE
Redraw zsh prompt after clearing screen

### DIFF
--- a/ssage_clear.sh
+++ b/ssage_clear.sh
@@ -21,4 +21,6 @@ ssage_clear() {
   else
     printf '\033[H\033[2J'
   fi
+
+  [[ -n $ZSH_VERSION && -o zle ]] && zle reset-prompt
 }


### PR DESCRIPTION
Currently ctrl+L keybinding removes the shell prompt. This PR redraws the zsh prompt after running ssage_clear. Only calls zle reset-prompt when running in an active zsh ZLE context